### PR TITLE
Boost/auto batch

### DIFF
--- a/src/main/java/com/github/boyeborg/spritz/EventConsumer.java
+++ b/src/main/java/com/github/boyeborg/spritz/EventConsumer.java
@@ -42,6 +42,11 @@ public class EventConsumer<T> {
 	 * @see #newBatch()
 	 */
 	public void addEvent(T event) {
+		if (currentBatch == null) {
+			// Auto add the first batch
+			newBatch();
+		}
+		
 		currentBatch.addEvent(event);
 	}
 

--- a/src/main/java/com/github/boyeborg/spritz/EventConsumer.java
+++ b/src/main/java/com/github/boyeborg/spritz/EventConsumer.java
@@ -22,9 +22,6 @@ public class EventConsumer<T> {
 	public EventConsumer(CollectorFactory<T> collectorFactory) {
 		this.collectorFactory = collectorFactory;
 		this.batches = new ArrayList<>();
-
-		// Add first batch
-		newBatch();
 	}
 
 	/**


### PR DESCRIPTION
### Pull Request checklist

- [x] Have you followed the contributing guidelines? 
 
### Description of your changes

A smarter way of adding the first batch. Now the logic for adding the batch is moved to where the events are added. This way, a new batch is only added if there does not exist a batch already, hence we remove the issue of having an empty batch at the beginning.

Fixes #40 
