### PR TITLE
output headers when calling `toString` on the event consumer

### DIFF
--- a/src/main/java/com/github/boyeborg/spritz/EventConsumer.java
+++ b/src/main/java/com/github/boyeborg/spritz/EventConsumer.java
@@ -98,6 +98,8 @@ public class EventConsumer<T> {
 	 */
 	@Override
 	public String toString() {
-		return batches.stream().map(Batch::toString).collect(Collectors.joining("\n"));
+		String headers = collectorFactory.names().stream().collect(Collectors.joining(","));
+		String results = batches.stream().map(Batch::toString).collect(Collectors.joining("\n"));
+		return headers + "\n" + results;
 	}
 }


### PR DESCRIPTION
### Pull Request checklist

- [x] Have you followed the contributing guidelines?
 
### Description of your changes

Add the headers when printing (toString-ign) the event consumer.