### PR TITLE
support batch naming

### DIFF
--- a/src/main/java/com/github/boyeborg/spritz/Batch.java
+++ b/src/main/java/com/github/boyeborg/spritz/Batch.java
@@ -10,14 +10,17 @@ import java.util.stream.Collectors;
 public class Batch<T> {
 
 	private List<ICollector<T>> collectors;
+	private String name;
 
 	/**
 	 * Creates a new batch.
 	 * 
 	 * @param collectorFactory A factory containing the generators to generate the collectors to use
 	 *     in the batch.
+	 * @param name The name of the batch
 	 */
-	public Batch(CollectorFactory<T> collectorFactory) {
+	public Batch(CollectorFactory<T> collectorFactory, String name) {
+		this.name = name;
 		collectors = new ArrayList<>();
 
 		collectorFactory.get().forEach(collectors::add);
@@ -71,10 +74,20 @@ public class Batch<T> {
 		return collectors;
 	}
 
+	/**
+	 * Returns the name of the Batch.
+	 * 
+	 * @return The name of the batch
+	 */
+	public String getName() {
+		return name;
+	}
+
 	@Override
 	public String toString() {
-		return collectors.stream()
-			.map(ICollector::getResult)
-			.collect(Collectors.joining(","));
+		String results = collectors.stream()
+				.map(ICollector::getResult)
+				.collect(Collectors.joining(","));
+		return name + "," + results;
 	}
 }

--- a/src/main/java/com/github/boyeborg/spritz/EventConsumer.java
+++ b/src/main/java/com/github/boyeborg/spritz/EventConsumer.java
@@ -13,6 +13,7 @@ public class EventConsumer<T> {
 	private List<Batch<T>> batches;
 	private Batch<T> currentBatch;
 	private CollectorFactory<T> collectorFactory;
+	private String batchNameDescription = "batchNumber";
 
 	/**
 	 * Constructor for the EventConsumer class.
@@ -25,13 +26,33 @@ public class EventConsumer<T> {
 	}
 
 	/**
+	 * Sets the description of the batch name, used in the header of the result.
+	 * 
+	 * @param description The description of the batch names
+	 */
+	public void setBatchNameDescription(String description) {
+		batchNameDescription = description;
+	}
+
+	/**
+	 * Adds a new batch and sets it as the current batch.
+	 * 
+	 * @param name The name of the batch
+	 * 
+	 * @see #addEvent(Object)
+	 */
+	public void newBatch(String name) {
+		currentBatch = new Batch<T>(collectorFactory, name);
+		batches.add(currentBatch);
+	}
+
+	/**
 	 * Adds a new batch and sets it as the current batch.
 	 * 
 	 * @see #addEvent(Object)
 	 */
 	public void newBatch() {
-		currentBatch = new Batch<T>(collectorFactory);
-		batches.add(currentBatch);
+		newBatch(String.format("Batch-%d", batches.size() + 1));
 	}
 
 	/**
@@ -100,6 +121,6 @@ public class EventConsumer<T> {
 	public String toString() {
 		String headers = collectorFactory.names().stream().collect(Collectors.joining(","));
 		String results = batches.stream().map(Batch::toString).collect(Collectors.joining("\n"));
-		return headers + "\n" + results;
+		return batchNameDescription + "," + headers + "\n" + results;
 	}
 }


### PR DESCRIPTION
### Pull Request checklist

- [x] Have you followed the contributing guidelines? 
 
### Description of your changes

Adds support for naming batches, and having that name included in both the results and the header. A custom name for the header can be supplied through the `setBatchNameDescription` method in the event consumer.